### PR TITLE
Don't let Chatpal prevent Rocket.Chat from starting

### DIFF
--- a/client/config/ui.js
+++ b/client/config/ui.js
@@ -23,8 +23,8 @@ Meteor.startup(function() {
 });
 
 RocketChat.callbacks.add('enter-room', () => {
-	Meteor.call('chatpal.config.get', (err, config) => {
-		if (!err && config.chatpalActivated) {
+	Meteor.call('chatpal.isActive', (err, activated) => {
+		if (!err && activated) {
 			RocketChat.TabBar.updateButton('message-search', {
 				i18nTitle: 'CHATPAL_SEARCH',
 				icon: 'chatpal',

--- a/server/base/backend.js
+++ b/server/base/backend.js
@@ -143,4 +143,6 @@ export const Chatpal = {
 	Backend: new ChatpalBackend(SystemLogger)
 };
 
-Meteor.startup(() => Chatpal.Backend.init()); //delay initialization so that a config has surely been created
+//delay initialization so that a config has surely been created
+//warpping it into a startup and separating initialization from creation stops chatpal preventing a Rocket.Chat startup
+Meteor.startup(() => Chatpal.Backend.init());

--- a/server/method/methods.js
+++ b/server/method/methods.js
@@ -81,6 +81,14 @@ Meteor.methods({
 });
 
 Meteor.methods({
+	'chatpal.isActive'() {
+
+		const config = RocketChat.models.Settings.findById('CHATPAL_CONFIG').fetch();
+		return config && config.length && config[0].value.chatpalActivated;
+	}
+});
+
+Meteor.methods({
 	'chatpal.utils.validatekey'(key) {
 		return Chatpal.Backend.validateKey(key);
 	}


### PR DESCRIPTION
Separate initialization from object creation.
This allows initialization to be wrapped in an after-startup-event.